### PR TITLE
various minor cleanup items

### DIFF
--- a/prophetess/app.py
+++ b/prophetess/app.py
@@ -10,7 +10,7 @@ from prophetess.pipeline import build_pipelines
 log = logging.getLogger(__name__)
 
 
-class Prophetess():
+class Prophetess:
 
     def __init__(self, config: Dict) -> None:
         self.config = config

--- a/prophetess/metrics.py
+++ b/prophetess/metrics.py
@@ -17,7 +17,8 @@ plugin_latency = Histogram(
 )
 
 
-class Timer():
+class Timer:
+
     def __init__(self, *, observer: Histogram, labels: Collection[str]) -> None:
         self.histogram = observer
         self._start_time = None

--- a/prophetess/pipeline.py
+++ b/prophetess/pipeline.py
@@ -39,8 +39,6 @@ def build_pipelines(cfg: Dict[str, Any]) -> 'Pipelines':
 
 
 class Pipelines(collections.OrderedDict):
-    def __init__(self):
-        pass
 
     async def close(self) -> None:
         for p in self.values():
@@ -53,7 +51,7 @@ class Pipelines(collections.OrderedDict):
         return '{}([{}])'.format(type(self).__name__, ', '.join([str(p) for p in self.values()]))
 
 
-class Pipeline():
+class Pipeline:
 
     def __init__(
             self, *,
@@ -106,7 +104,7 @@ class Pipeline():
             try:
                 await l.run(record)
             except ProphetessException as e:
-                log.warn('{} Loader failed: {}'.format(l.id, e))
+                log.warning('{} Loader failed: {}'.format(l.id, e))
             except Exception as e:
                 log.error('{} raised unexpected exception: {}'.format(l.id, e))
             finally:

--- a/prophetess/plugin.py
+++ b/prophetess/plugin.py
@@ -57,7 +57,8 @@ class Loader(PluginBase):
 
 class Transformer(PluginBase):
 
-    def format(self, string: str, mapping: Dict[str, Any]) -> str:
+    @staticmethod
+    def format(string: str, mapping: Dict[str, Any]) -> str:
         return string.format(**mapping)
 
     def parse(self, keys: Union[str, Dict[str, Any]], values: Dict[str, Any]) -> Union[str, Dict[str, Any]]:

--- a/prophetess/utils.py
+++ b/prophetess/utils.py
@@ -16,6 +16,10 @@ def build_plugin(plugin_type: str, plugin_id: str, plugin_config: Dict[str, Any]
         raise InvalidPlugin(f'{plugin_name} not found, try `pip install prophetess-{module_name}`?')
 
     name = plugin_config.get('class', '{}{}'.format(plugin_name, plugin_type))
-    plugin = getattr(config.PLUGINS.get(module_name), name)
+    plugin_class = getattr(config.PLUGINS.get(module_name), name)
 
-    return plugin(id=plugin_id, config=plugin_config.get('config'), labels=(plugin_name, plugin_type, name))
+    return plugin_class(
+        id=plugin_id,
+        config=plugin_config.get('config'),
+        labels=(plugin_name, plugin_type, name),
+    )


### PR DESCRIPTION
This PR:
- performs some cleanup items which are not linting violations, but are not necessarily "best practices" for py3
- fix two uses of deprecated methods:
    - `log.warn` is deprecated, use `log.warning` instead
    - `app.make_handler` is deprecated, use an AppRunner instead
- fixes what might potentially be a bug in that the `PORT` configuration was not being used by the web app handler, so no matter what the port was configured to, it would always end up being 8080.
- fixes a name collision. (`plugin` -> `plugin_class`) `plugin` is an imported module. while in this case, there aren't any adverse effects, it still seems like a good idea to do this. 