### PR TITLE
make Timer class a context manager for easier basic time captures

### DIFF
--- a/prophetess/metrics.py
+++ b/prophetess/metrics.py
@@ -24,6 +24,12 @@ class Timer:
         self._start_time = None
         self.labels = labels
 
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
     def start(self) -> None:
         self._start_time = time.time()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from prophetess import metrics
 
 
@@ -40,6 +42,43 @@ class TestTimer:
         )
         t.start()
         t.stop()
+
+        assert t._start_time == 123456
+        observe_mock.assert_called_once_with(4)
+
+    @patch('time.time')
+    @patch('prometheus_client.Histogram.observe')
+    def test_context_managed_ok(self, observe_mock, time_mock):
+        # NOTE: need three time values here because it appears that time.time is called
+        #  somewhere else in the call path, likely within a dependency.
+        time_mock.side_effect = [123456, 123460, 123462]
+
+        t = metrics.Timer(
+            observer=metrics.plugin_latency,
+            labels=('a', 'b', 'c', 'd'),
+        )
+
+        with t:
+            pass
+
+        assert t._start_time == 123456
+        observe_mock.assert_called_once_with(4)
+
+    @patch('time.time')
+    @patch('prometheus_client.Histogram.observe')
+    def test_context_managed_on_exception(self, observe_mock, time_mock):
+        # NOTE: need three time values here because it appears that time.time is called
+        #  somewhere else in the call path, likely within a dependency.
+        time_mock.side_effect = [123456, 123460, 123462]
+
+        t = metrics.Timer(
+            observer=metrics.plugin_latency,
+            labels=('a', 'b', 'c', 'd'),
+        )
+
+        with pytest.raises(ValueError):
+            with t:
+                raise ValueError()
 
         assert t._start_time == 123456
         observe_mock.assert_called_once_with(4)


### PR DESCRIPTION
This PR:
- makes the Timer class a context manager, allowing timing info to be collected a bit easier using a `with` statement

fixes #1 